### PR TITLE
bugfix: restart to initialize from previous timestep

### DIFF
--- a/models/ColorModel.cpp
+++ b/models/ColorModel.cpp
@@ -111,6 +111,9 @@ void ScaLBL_ColorModel::ReadParams(string filename) {
     if (color_db->keyExists("flux")) {
         flux = color_db->getScalar<double>("flux");
     }
+    if (color_db->keyExists("timestep")) {
+        timestep = color_db->getScalar<int>("timestep");
+    }
     inletA = 1.f;
     inletB = 0.f;
     outletA = 0.f;


### PR DESCRIPTION
# Bugfix
- The timestep of the Restart.db was never read, leading to a restart starting with timestep = 0 and overwriting previous output files (i.e., the `id_t<timestep>.raw` files)