### PR TITLE
body force adjustment: scale-then-bisect algorithm

### DIFF
--- a/models/ColorModel.h
+++ b/models/ColorModel.h
@@ -89,6 +89,11 @@ public:
     void Initialize();
 
     /**
+    * \brief Forward propagation step
+    */
+    void ForwardStep();
+
+    /**
     * \brief Run the simulation
     */
     void Run();


### PR DESCRIPTION

# Feature
- Improved body force search algorithm for steady state calculations
- Currently, the body force is proportionally adjusted to achieve the desired capillary number, but because these properties are non-linearly related, the proportional scaling was prone to 'straddling' the target and infinitely bouncing back-and-forth (as identified in #75). 
- Now, once the proportional scaling brackets the target, we switch to the bisection method for guaranteed convergence. 
- Resolves https://github.com/OPM/LBPM/issues/75.

# To do
- [x] Investigating potential further issue for low capillary number simulations, where the desired capillary number is below that of the spurious current. This results in an 'infinite halving' of the body force, where each lowering does not affect the measured capillary number since it is already dominated by spurious currents. 