### PR TITLE
Bugfix: maximum pore size 

### DIFF
--- a/analysis/morphology.cpp
+++ b/analysis/morphology.cpp
@@ -508,7 +508,7 @@ double MorphOpen(DoubleArray &SignDist, signed char *id,
 
     // total Global is the number of nodes in the pore-space
     totalGlobal = Dm->Comm.sumReduce(count);
-    maxdistGlobal = Dm->Comm.sumReduce(maxdist);
+    maxdistGlobal = Dm->Comm.maxReduce(maxdist);
     double volume = double(nprocx * nprocy * nprocz) * double(nx - 2) *
                     double(ny - 2) * double(nz - 2);
     double volume_fraction = totalGlobal / volume;


### PR DESCRIPTION
This fixes a small bug where the maximum distance was computed using sumReduce rather than maxReduce. As a result, the reported maximum pore size for the sample was incorrect and varied with the number of tasks used.

Because both the bug and the fix are very clear, I’m submitting this directly as a PR for the record.

